### PR TITLE
Fix #8 - mass update of tests with minor workarounds

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -16,7 +16,7 @@ config :ae_canary, AeCanary.Repo,
 # watchers to your application. For example, we use it
 # with webpack to recompile .js and .css sources.
 config :ae_canary, AeCanaryWeb.Endpoint,
-  http: [port: 3013],
+  http: [port: 4013],
   debug_errors: true,
   code_reloader: true,
   check_origin: false,

--- a/config/test.exs
+++ b/config/test.exs
@@ -18,5 +18,8 @@ config :ae_canary, AeCanaryWeb.Endpoint,
   http: [port: 4002],
   server: false
 
+config :ae_canary, AeCanary.Mdw.Cache.Service,
+  startup_delay: 240000
+
 # Print only warnings and errors during test
 config :logger, level: :warn

--- a/lib/ae_canary/mdw/cache/service.ex
+++ b/lib/ae_canary/mdw/cache/service.ex
@@ -1,5 +1,4 @@
 defmodule AeCanary.Mdw.Cache.Service do
-
   defmodule State do
     defstruct [:data, :refresh_start_tmst, :refresh_end_tmst, :last_refresh_length]
   end
@@ -8,7 +7,7 @@ defmodule AeCanary.Mdw.Cache.Service do
   @callback cache_handle() :: atom()
   @callback refresh_interval() :: integer()
   @callback refresh() :: term()
- 
+
   defmacro __using__(name: name) do
     quote do
       alias AeCanary.Mdw
@@ -37,20 +36,28 @@ defmodule AeCanary.Mdw.Cache.Service do
       def handle_call(:get, _from, state) do
         {:reply, state.data, state}
       end
+
       def handle_call(:stats, _from, state) do
         stats =
           case state.refresh_start_tmst do
             nil when state.refresh_end_tmst == nil ->
               %{}
+
             nil ->
-              %{ongoing_update: false,
+              %{
+                ongoing_update: false,
                 last_refresh_length: state.last_refresh_length,
-                refresh_end_tmst: state.refresh_end_tmst}
+                refresh_end_tmst: state.refresh_end_tmst
+              }
+
             _ ->
-              %{ongoing_update: true,
+              %{
+                ongoing_update: true,
                 last_refresh_length: state.last_refresh_length,
-                refresh_start_tmst: state.refresh_start_tmst}
+                refresh_start_tmst: state.refresh_start_tmst
+              }
           end
+
         {:reply, stats, state}
       end
 
@@ -59,12 +66,25 @@ defmodule AeCanary.Mdw.Cache.Service do
         start_refresh_timer()
         {:noreply, %State{state | refresh_start_tmst: now(), refresh_end_tmst: nil}}
       end
+
       def handle_info({:set, data}, state) do
         AeCanary.Mdw.Cache.set_data(cache_handle(), data)
         now = now()
-        last_refresh_length = Timex.diff(now, state.refresh_start_tmst, :millisecond) |> Timex.Duration.from_milliseconds()
-        {:noreply, %{state | data: data, refresh_end_tmst: now, refresh_start_tmst: nil, last_refresh_length: last_refresh_length}}
+
+        last_refresh_length =
+          Timex.diff(now, state.refresh_start_tmst, :millisecond)
+          |> Timex.Duration.from_milliseconds()
+
+        {:noreply,
+         %{
+           state
+           | data: data,
+             refresh_end_tmst: now,
+             refresh_start_tmst: nil,
+             last_refresh_length: last_refresh_length
+         }}
       end
+
       #
       # API
       def get() do
@@ -87,12 +107,24 @@ defmodule AeCanary.Mdw.Cache.Service do
       defp start_refresh_timer() do
         start_refresh_timer(:normal)
       end
+
       defp start_refresh_timer(type) do
         milliseconds =
           case type do
-            :initial -> 0
-            _ -> refresh_interval()
+            :initial ->
+              ## Bit of an ugly hack to allow the unit tests to run in a node that
+              ## doesn't start these services until long after the tests are finished.
+              ## If we can work out a way for the Exchange service to access Ecto
+              ## outside all the Exunit Ecto pools we can remove this.
+              case Application.fetch_env(:ae_canary, AeCanary.Mdw.Cache.Service) do
+                :error -> 0
+                {:ok, v} -> Keyword.get(v, :startup_delay, 0)
+              end
+
+            _ ->
+              refresh_interval()
           end
+
         Process.send_after(self(), :refresh_data, milliseconds)
       end
 
@@ -105,5 +137,4 @@ defmodule AeCanary.Mdw.Cache.Service do
       end
     end
   end
-
 end

--- a/lib/ae_canary/mdw/cache/service/exchange.ex
+++ b/lib/ae_canary/mdw/cache/service/exchange.ex
@@ -7,7 +7,7 @@ defmodule AeCanary.Mdw.Cache.Service.Exchange do
   alias AeCanary.Statistics.InterquartileRange, as: IR
 
   @impl true
-  def init(), do: nil 
+  def init(), do: nil
 
   @impl true
   def refresh_interval(), do: minutes(10)

--- a/lib/ae_canary/mdw/cache/service/tainted_accounts.ex
+++ b/lib/ae_canary/mdw/cache/service/tainted_accounts.ex
@@ -2,7 +2,7 @@ defmodule AeCanary.Mdw.Cache.Service.TaintedAccounts do
   use AeCanary.Mdw.Cache.Service, name: "[WIP] Tainted accounts"
 
   @impl true
-  def init(), do: nil 
+  def init(), do: nil
 
   @impl true
   def refresh_interval(), do: seconds(20)

--- a/lib/ae_canary/transactions/spend.ex
+++ b/lib/ae_canary/transactions/spend.ex
@@ -3,6 +3,7 @@ defmodule AeCanary.Transactions.Spend do
   import Ecto.Changeset
 
   @primary_key {:hash, :string, autogenerate: false}
+  @derive {Phoenix.Param, key: :hash}
   schema "spend_txs" do
     field :amount, :float
     field :fee, :float

--- a/lib/ae_canary_web/templates/exchanges/address/index.html.eex
+++ b/lib/ae_canary_web/templates/exchanges/address/index.html.eex
@@ -14,7 +14,7 @@
 <%= for address <- @addresses do %>
     <tr>
       <td><%= address.addr %></td>
-      <td><%= String.slice(address.comment, 0, max_comment_length)%><%= if address.comment != nil and String.length(address.comment) > max_comment_length do %>...<% end %></td>
+      <td><%= if address.comment != nil do String.slice(address.comment, 0, max_comment_length) end%><%= if address.comment != nil and String.length(address.comment) > max_comment_length do %>...<% end %></td>
 
       <td>
         <span><%= link "Show", to: Routes.exchanges_address_path(@conn, :show, address), class: "btn btn-light" %></span>

--- a/lib/ae_canary_web/templates/exchanges/exchange/index.html.eex
+++ b/lib/ae_canary_web/templates/exchanges/exchange/index.html.eex
@@ -14,7 +14,7 @@
     <%= for exchange <- @exchanges do %>
     <tr>
       <td><%= exchange.name %></td>
-      <td><%= String.slice(exchange.comment, 0, max_comment_length)%><%= if exchange.comment != nil and String.length(exchange.comment) > max_comment_length do %>...<% end %></td>
+      <td><%= if exchange.comment != nil do String.slice(exchange.comment, 0, max_comment_length) end%><%= if exchange.comment != nil and String.length(exchange.comment) > max_comment_length do %>...<% end %></td>
 
       <td>
         <span><%= link "Show", to: Routes.exchanges_exchange_path(@conn, :show, exchange), class: "btn btn-light btn-sm" %></span>

--- a/lib/ae_canary_web/templates/page/service.html.eex
+++ b/lib/ae_canary_web/templates/page/service.html.eex
@@ -6,12 +6,12 @@
   <div class="card-body">
     <p>Status <span class="text-success">OK</span></p>
     <p class="text-muted">Updates every <%= format_milliseconds(@service.refresh_interval) %></p>
-    <%= if stats.last_refresh_length do%>
+    <%= if stats[:last_refresh_length] do%>
       <p class="text-muted">Last update took <%= Elixir.Timex.Format.Duration.Formatters.Humanized.format(stats.last_refresh_length) %></p>
     <% end %>
   </div>
   <div class="card-footer">
-    <%= if stats.ongoing_update do%>
+    <%= if stats[:ongoing_update] do%>
       <small class="text-muted">Updating data.</small>
     <% end %>
     <%= if stats[:refresh_end_tmst]do%>

--- a/test/ae_canary/exchanges_test.exs
+++ b/test/ae_canary/exchanges_test.exs
@@ -72,6 +72,9 @@ defmodule AeCanary.ExchangesTest do
     @invalid_attrs %{addr: nil, comment: nil}
 
     def address_fixture(attrs \\ %{}) do
+      exchange = exchange_fixture()
+      attrs = Map.put(attrs, :exchange_id, exchange.id)
+
       {:ok, address} =
         attrs
         |> Enum.into(@valid_attrs)
@@ -91,7 +94,9 @@ defmodule AeCanary.ExchangesTest do
     end
 
     test "create_address/1 with valid data creates a address" do
-      assert {:ok, %Address{} = address} = Exchanges.create_address(@valid_attrs)
+      exchange = exchange_fixture()
+      attrs = Map.put(@valid_attrs, :exchange_id, exchange.id)
+      assert {:ok, %Address{} = address} = Exchanges.create_address(attrs)
       assert address.addr == "some addr"
       assert address.comment == "some comment"
     end

--- a/test/ae_canary/settings_test.exs
+++ b/test/ae_canary/settings_test.exs
@@ -6,9 +6,9 @@ defmodule AeCanary.SettingsTest do
   describe "dashboard" do
     alias AeCanary.Settings.Dashboard
 
-    @valid_attrs %{active: true, message: "some message", state: "some state"}
-    @update_attrs %{active: false, message: "some updated message", state: "some updated state"}
-    @invalid_attrs %{active: nil, message: nil, state: nil}
+    @valid_attrs %{active: true, title: "some title", message: "some message", state: "normal"}
+    @update_attrs %{active: false, title: "some updated title", message: "some updated message", state: "warning"}
+    @invalid_attrs %{active: nil, title: nil, message: nil, state: nil}
 
     def dashboard_fixture(attrs \\ %{}) do
       {:ok, dashboard} =
@@ -33,7 +33,7 @@ defmodule AeCanary.SettingsTest do
       assert {:ok, %Dashboard{} = dashboard} = Settings.create_dashboard(@valid_attrs)
       assert dashboard.active == true
       assert dashboard.message == "some message"
-      assert dashboard.state == "some state"
+      assert dashboard.state == "normal"
     end
 
     test "create_dashboard/1 with invalid data returns error changeset" do
@@ -45,7 +45,7 @@ defmodule AeCanary.SettingsTest do
       assert {:ok, %Dashboard{} = dashboard} = Settings.update_dashboard(dashboard, @update_attrs)
       assert dashboard.active == false
       assert dashboard.message == "some updated message"
-      assert dashboard.state == "some updated state"
+      assert dashboard.state == "warning"
     end
 
     test "update_dashboard/2 with invalid data returns error changeset" do

--- a/test/ae_canary/transactions_test.exs
+++ b/test/ae_canary/transactions_test.exs
@@ -26,7 +26,7 @@ defmodule AeCanary.TransactionsTest do
 
     test "get_spend!/1 returns the spend with given id" do
       spend = spend_fixture()
-      assert Transactions.get_spend!(spend.id) == spend
+      assert Transactions.get_spend!(spend.hash) == spend
     end
 
     test "create_spend/1 with valid data creates a spend" do
@@ -57,13 +57,13 @@ defmodule AeCanary.TransactionsTest do
     test "update_spend/2 with invalid data returns error changeset" do
       spend = spend_fixture()
       assert {:error, %Ecto.Changeset{}} = Transactions.update_spend(spend, @invalid_attrs)
-      assert spend == Transactions.get_spend!(spend.id)
+      assert spend == Transactions.get_spend!(spend.hash)
     end
 
     test "delete_spend/1 deletes the spend" do
       spend = spend_fixture()
       assert {:ok, %Spend{}} = Transactions.delete_spend(spend)
-      assert_raise Ecto.NoResultsError, fn -> Transactions.get_spend!(spend.id) end
+      assert_raise Ecto.NoResultsError, fn -> Transactions.get_spend!(spend.hash) end
     end
 
     test "change_spend/1 returns a spend changeset" do
@@ -75,8 +75,8 @@ defmodule AeCanary.TransactionsTest do
   describe "location" do
     alias AeCanary.Transactions.Location
 
-    @valid_attrs %{block_hash: "some block_hash", block_height: "some block_height", micro_time: "2010-04-17T14:00:00Z", tx_hash: "some tx_hash"}
-    @update_attrs %{block_hash: "some updated block_hash", block_height: "some updated block_height", micro_time: "2011-05-18T15:01:01Z", tx_hash: "some updated tx_hash"}
+    @valid_attrs %{block_hash: "some block_hash", block_height: 100, micro_time: "2010-04-17T14:00:00Z", tx_hash: "some tx_hash"}
+    @update_attrs %{block_hash: "some updated block_hash", block_height: 101, micro_time: "2011-05-18T15:01:01Z", tx_hash: "some updated tx_hash"}
     @invalid_attrs %{block_hash: nil, block_height: nil, micro_time: nil, tx_hash: nil}
 
     def location_fixture(attrs \\ %{}) do
@@ -101,7 +101,7 @@ defmodule AeCanary.TransactionsTest do
     test "create_location/1 with valid data creates a location" do
       assert {:ok, %Location{} = location} = Transactions.create_location(@valid_attrs)
       assert location.block_hash == "some block_hash"
-      assert location.block_height == "some block_height"
+      assert location.block_height == 100
       assert location.micro_time == DateTime.from_naive!(~N[2010-04-17T14:00:00Z], "Etc/UTC")
       assert location.tx_hash == "some tx_hash"
     end
@@ -114,7 +114,7 @@ defmodule AeCanary.TransactionsTest do
       location = location_fixture()
       assert {:ok, %Location{} = location} = Transactions.update_location(location, @update_attrs)
       assert location.block_hash == "some updated block_hash"
-      assert location.block_height == "some updated block_height"
+      assert location.block_height == 101
       assert location.micro_time == DateTime.from_naive!(~N[2011-05-18T15:01:01Z], "Etc/UTC")
       assert location.tx_hash == "some updated tx_hash"
     end

--- a/test/ae_canary_web/controllers/dashboard_controller_test.exs
+++ b/test/ae_canary_web/controllers/dashboard_controller_test.exs
@@ -3,9 +3,11 @@ defmodule AeCanaryWeb.DashboardControllerTest do
 
   alias AeCanary.Settings
 
-  @create_attrs %{active: true, message: "some message", state: "some state"}
-  @update_attrs %{active: false, message: "some updated message", state: "some updated state"}
-  @invalid_attrs %{active: nil, message: nil, state: nil}
+  @moduletag :authenticated
+
+  @create_attrs %{active: true, title: "some title", message: "some message", state: "normal"}
+  @update_attrs %{active: false, title: "some updated title", message: "some updated message", state: "warning"}
+  @invalid_attrs %{active: nil, title: nil, message: nil, state: nil}
 
   def fixture(:dashboard) do
     {:ok, dashboard} = Settings.create_dashboard(@create_attrs)
@@ -15,14 +17,14 @@ defmodule AeCanaryWeb.DashboardControllerTest do
   describe "index" do
     test "lists all dashboard", %{conn: conn} do
       conn = get(conn, Routes.dashboard_path(conn, :index))
-      assert html_response(conn, 200) =~ "Listing Dashboard"
+      assert html_response(conn, 200) =~ "Dashboard messages"
     end
   end
 
   describe "new dashboard" do
     test "renders form", %{conn: conn} do
       conn = get(conn, Routes.dashboard_path(conn, :new))
-      assert html_response(conn, 200) =~ "New Dashboard"
+      assert html_response(conn, 200) =~ "New dashboard message"
     end
   end
 
@@ -34,12 +36,12 @@ defmodule AeCanaryWeb.DashboardControllerTest do
       assert redirected_to(conn) == Routes.dashboard_path(conn, :show, id)
 
       conn = get(conn, Routes.dashboard_path(conn, :show, id))
-      assert html_response(conn, 200) =~ "Show Dashboard"
+      assert html_response(conn, 200) =~ "Dashboard created successfully"
     end
 
     test "renders errors when data is invalid", %{conn: conn} do
       conn = post(conn, Routes.dashboard_path(conn, :create), dashboard: @invalid_attrs)
-      assert html_response(conn, 200) =~ "New Dashboard"
+      assert html_response(conn, 200) =~ "New dashboard"
     end
   end
 

--- a/test/ae_canary_web/controllers/exchanges/exchange_controller_test.exs
+++ b/test/ae_canary_web/controllers/exchanges/exchange_controller_test.exs
@@ -3,6 +3,8 @@ defmodule AeCanaryWeb.Exchanges.ExchangeControllerTest do
 
   alias AeCanary.Exchanges
 
+  @moduletag :authenticated
+
   @create_attrs %{comment: "some comment", name: "some name"}
   @update_attrs %{comment: "some updated comment", name: "some updated name"}
   @invalid_attrs %{comment: nil, name: nil}
@@ -34,7 +36,7 @@ defmodule AeCanaryWeb.Exchanges.ExchangeControllerTest do
       assert redirected_to(conn) == Routes.exchanges_exchange_path(conn, :show, id)
 
       conn = get(conn, Routes.exchanges_exchange_path(conn, :show, id))
-      assert html_response(conn, 200) =~ "Show Exchange"
+      assert html_response(conn, 200) =~ "Exchange created successfully"
     end
 
     test "renders errors when data is invalid", %{conn: conn} do

--- a/test/ae_canary_web/controllers/page_controller_test.exs
+++ b/test/ae_canary_web/controllers/page_controller_test.exs
@@ -3,6 +3,6 @@ defmodule AeCanaryWeb.PageControllerTest do
 
   test "GET /", %{conn: conn} do
     conn = get(conn, "/")
-    assert html_response(conn, 200) =~ "This is the public dashboard."
+    assert html_response(conn, 200) =~ "In order to see the functionality"
   end
 end

--- a/test/ae_canary_web/controllers/tainted_accounts/account_controller_test.exs
+++ b/test/ae_canary_web/controllers/tainted_accounts/account_controller_test.exs
@@ -3,6 +3,8 @@ defmodule AeCanaryWeb.TaintedAccounts.AccountControllerTest do
 
   alias AeCanary.TaintedAccounts
 
+  @moduletag :authenticated
+
   @create_attrs %{addr: "some addr", amount: 42, comment: "some comment", from_height: 42, last_tx_height: 42, white_listed: true}
   @update_attrs %{addr: "some updated addr", amount: 43, comment: "some updated comment", from_height: 43, last_tx_height: 43, white_listed: false}
   @invalid_attrs %{addr: nil, amount: nil, comment: nil, from_height: nil, last_tx_height: nil, white_listed: nil}
@@ -15,14 +17,14 @@ defmodule AeCanaryWeb.TaintedAccounts.AccountControllerTest do
   describe "index" do
     test "lists all accounts", %{conn: conn} do
       conn = get(conn, Routes.tainted_accounts_account_path(conn, :index))
-      assert html_response(conn, 200) =~ "Listing Accounts"
+      assert html_response(conn, 200) =~ "Listing tainted accounts"
     end
   end
 
   describe "new account" do
     test "renders form", %{conn: conn} do
       conn = get(conn, Routes.tainted_accounts_account_path(conn, :new))
-      assert html_response(conn, 200) =~ "New Account"
+      assert html_response(conn, 200) =~ "New tainted account"
     end
   end
 
@@ -39,7 +41,7 @@ defmodule AeCanaryWeb.TaintedAccounts.AccountControllerTest do
 
     test "renders errors when data is invalid", %{conn: conn} do
       conn = post(conn, Routes.tainted_accounts_account_path(conn, :create), account: @invalid_attrs)
-      assert html_response(conn, 200) =~ "New Account"
+      assert html_response(conn, 200) =~ "New tainted account"
     end
   end
 
@@ -48,7 +50,7 @@ defmodule AeCanaryWeb.TaintedAccounts.AccountControllerTest do
 
     test "renders form for editing chosen account", %{conn: conn, account: account} do
       conn = get(conn, Routes.tainted_accounts_account_path(conn, :edit, account))
-      assert html_response(conn, 200) =~ "Edit Account"
+      assert html_response(conn, 200) =~ "Edit tainted account"
     end
   end
 
@@ -65,7 +67,7 @@ defmodule AeCanaryWeb.TaintedAccounts.AccountControllerTest do
 
     test "renders errors when data is invalid", %{conn: conn, account: account} do
       conn = put(conn, Routes.tainted_accounts_account_path(conn, :update, account), account: @invalid_attrs)
-      assert html_response(conn, 200) =~ "Edit Account"
+      assert html_response(conn, 200) =~ "Edit tainted account"
     end
   end
 

--- a/test/ae_canary_web/controllers/transactions/location_controller_test.exs
+++ b/test/ae_canary_web/controllers/transactions/location_controller_test.exs
@@ -3,8 +3,10 @@ defmodule AeCanaryWeb.Transactions.LocationControllerTest do
 
   alias AeCanary.Transactions
 
-  @create_attrs %{block_hash: "some block_hash", block_height: "some block_height", micro_time: "2010-04-17T14:00:00Z", tx_hash: "some tx_hash"}
-  @update_attrs %{block_hash: "some updated block_hash", block_height: "some updated block_height", micro_time: "2011-05-18T15:01:01Z", tx_hash: "some updated tx_hash"}
+  @moduletag :authenticated
+
+  @create_attrs %{block_hash: "some block_hash", block_height: 100, micro_time: "2010-04-17T14:00:00Z", tx_hash: "some tx_hash"}
+  @update_attrs %{block_hash: "some updated block_hash", block_height: 101, micro_time: "2011-05-18T15:01:01Z", tx_hash: "some updated tx_hash"}
   @invalid_attrs %{block_hash: nil, block_height: nil, micro_time: nil, tx_hash: nil}
 
   def fixture(:location) do

--- a/test/ae_canary_web/controllers/transactions/spend_controller_test.exs
+++ b/test/ae_canary_web/controllers/transactions/spend_controller_test.exs
@@ -3,9 +3,31 @@ defmodule AeCanaryWeb.Transactions.SpendControllerTest do
 
   alias AeCanary.Transactions
 
-  @create_attrs %{amount: 42, fee: 42, hash: "some hash", nonce: 42, recipient_id: "some recipient_id", sender_id: "some sender_id"}
-  @update_attrs %{amount: 43, fee: 43, hash: "some updated hash", nonce: 43, recipient_id: "some updated recipient_id", sender_id: "some updated sender_id"}
-  @invalid_attrs %{amount: nil, fee: nil, hash: nil, nonce: nil, recipient_id: nil, sender_id: nil}
+  @create_attrs %{
+    amount: 42,
+    fee: 42,
+    hash: "some_hash",
+    nonce: 42,
+    recipient_id: "some recipient_id",
+    sender_id: "some sender_id"
+  }
+  @update_attrs %{
+    amount: 43,
+    fee: 43,
+    nonce: 43,
+    recipient_id: "some updated recipient_id",
+    sender_id: "some updated sender_id"
+  }
+  @invalid_attrs %{
+    amount: nil,
+    fee: nil,
+    hash: nil,
+    nonce: nil,
+    recipient_id: nil,
+    sender_id: nil
+  }
+
+  @moduletag :authenticated
 
   def fixture(:spend) do
     {:ok, spend} = Transactions.create_spend(@create_attrs)
@@ -57,14 +79,19 @@ defmodule AeCanaryWeb.Transactions.SpendControllerTest do
 
     test "redirects when data is valid", %{conn: conn, spend: spend} do
       conn = put(conn, Routes.transactions_spend_path(conn, :update, spend), spend: @update_attrs)
+      ## This would cause the test harness some trouble if we also updated the hash
+      ## - we would then be updating the primary key so would need to use the new spend after here
+      ## It should be enough to show that we can update the sender_id
       assert redirected_to(conn) == Routes.transactions_spend_path(conn, :show, spend)
 
       conn = get(conn, Routes.transactions_spend_path(conn, :show, spend))
-      assert html_response(conn, 200) =~ "some updated hash"
+      assert html_response(conn, 200) =~ "some updated sender_id"
     end
 
     test "renders errors when data is invalid", %{conn: conn, spend: spend} do
-      conn = put(conn, Routes.transactions_spend_path(conn, :update, spend), spend: @invalid_attrs)
+      conn =
+        put(conn, Routes.transactions_spend_path(conn, :update, spend), spend: @invalid_attrs)
+
       assert html_response(conn, 200) =~ "Edit Spend"
     end
   end
@@ -75,6 +102,7 @@ defmodule AeCanaryWeb.Transactions.SpendControllerTest do
     test "deletes chosen spend", %{conn: conn, spend: spend} do
       conn = delete(conn, Routes.transactions_spend_path(conn, :delete, spend))
       assert redirected_to(conn) == Routes.transactions_spend_path(conn, :index)
+
       assert_error_sent 404, fn ->
         get(conn, Routes.transactions_spend_path(conn, :show, spend))
       end


### PR DESCRIPTION
Lots of routine test updates.

The only tricky part is disabling the poolboy services during testing as they make use of Ecto and cause chaos with the ExUnit ecto setup.