### PR TITLE
Use Decimal type for db storage and lookups

### DIFF
--- a/lib/ae_canary/notifications/notification.ex
+++ b/lib/ae_canary/notifications/notification.ex
@@ -12,15 +12,15 @@ defmodule AeCanary.Notifications.Notification do
   """
   schema "notifications" do
     field :addr, :string
-    field :amount, :float
+    field :amount, :decimal
     field :boundary, Ecto.Enum, values: [:upper, :lower]
     field :delivered, :boolean
     field :email, :string
     field :event_datetime, :utc_datetime
     field :event_date, :date
     field :event_type, Ecto.Enum, values: [:big_deposit, :boundary, :fork]
-    field :exposure, :float
-    field :limit, :float
+    field :exposure, :decimal
+    field :limit, :decimal
     field :sent, :boolean
     field :tx_hash, :string
 

--- a/priv/repo/migrations/20210617145203_create_notifications.exs
+++ b/priv/repo/migrations/20210617145203_create_notifications.exs
@@ -11,10 +11,10 @@ defmodule AeCanary.Repo.Migrations.CreateNotifications do
       add :delivered, :boolean
       add :addr, :string
       add :boundary, :string
-      add :exposure, :float
-      add :limit, :float
+      add :exposure, :numeric
+      add :limit, :numeric
       add :tx_hash, :string
-      add :amount, :float
+      add :amount, :numeric
 
       timestamps()
     end

--- a/test/ae_canary/notifications_test.exs
+++ b/test/ae_canary/notifications_test.exs
@@ -14,7 +14,8 @@ defmodule AeCanary.NotificationsTest do
       exposure: 120.5,
       limit: 120.5,
       tx_hash: "some tx_hash",
-      event_date: ~U[2021-06-17 15:15:51.095096Z]
+      event_date: ~D[2021-06-17],
+      event_datetime: ~U[2021-06-17 15:15:51.095096Z]
     }
     @update_attrs %{
       addr: "some updated addr",
@@ -22,9 +23,10 @@ defmodule AeCanary.NotificationsTest do
       boundary: "lower",
       event_type: "big_deposit",
       exposure: 456.7,
-      limit: 456.7,
+      limit: 456.870835528854899254093987364832,
       tx_hash: "some updated tx_hash",
-      event_date: ~U[2021-06-17 15:15:51.095096Z]
+      event_date: ~D[2021-06-18],
+      event_datetime: ~U[2021-06-18 15:15:51.095096Z]
     }
     @invalid_attrs %{
       addr: nil,
@@ -56,16 +58,36 @@ defmodule AeCanary.NotificationsTest do
       assert Notifications.get_notification!(notification.id) == notification
     end
 
+    test "list_over_boundaries/5 returns the notification with given parameters" do
+      notification = notification_fixture()
+
+      assert Notifications.list_over_boundaries(
+               "some addr",
+               "upper",
+               ~D[2021-06-17],
+               120.5,
+               120.5
+             ) == [notification]
+    end
+
+    test "list_big_deposits/2 returns the notification with given parameters" do
+      notification = notification_fixture(@update_attrs)
+
+      assert Notifications.list_big_deposits("some updated addr", "some updated tx_hash") == [
+               notification
+             ]
+    end
+
     test "create_notification/1 with valid data creates a notification" do
       assert {:ok, %Notification{} = notification} =
                Notifications.create_notification(@valid_attrs)
 
       assert notification.addr == "some addr"
-      assert notification.amount == 120.5
+      assert notification.amount == Decimal.from_float(120.5)
       assert notification.boundary == :upper
       assert notification.event_type == :boundary
-      assert notification.exposure == 120.5
-      assert notification.limit == 120.5
+      assert notification.exposure == Decimal.from_float(120.5)
+      assert notification.limit == Decimal.from_float(120.5)
       assert notification.tx_hash == "some tx_hash"
     end
 
@@ -80,11 +102,11 @@ defmodule AeCanary.NotificationsTest do
                Notifications.update_notification(notification, @update_attrs)
 
       assert notification.addr == "some updated addr"
-      assert notification.amount == 456.7
+      assert notification.amount == Decimal.from_float(456.7)
       assert notification.boundary == :lower
       assert notification.event_type == :big_deposit
-      assert notification.exposure == 456.7
-      assert notification.limit == 456.7
+      assert notification.exposure == Decimal.from_float(456.7)
+      assert notification.limit == Decimal.from_float(456.870835528854899254093987364832)
       assert notification.tx_hash == "some updated tx_hash"
     end
 


### PR DESCRIPTION
This should fix the duplicate emails problem caused by the same float being stored at multiple precisions in the database.

The default precision chosen by Ecto for the :decimal type seems perfectly fine (12 decimal digits)

This PR was funded by the ACF