### PR TITLE
Add configuration of host used in links in emails

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -9,7 +9,8 @@ use Mix.Config
 
 config :ae_canary,
   ecto_repos: [AeCanary.Repo],
-  mdw_url: "http://18.156.189.185/mdw/"
+  mdw_url: "http://18.156.189.185/mdw/",
+  site_address: "localhost"
 
 # Configures the endpoint
 config :ae_canary, AeCanaryWeb.Endpoint,

--- a/config/prod.secret.exs
+++ b/config/prod.secret.exs
@@ -45,6 +45,14 @@ mdw_url =
     This is the address of the Aeternity MDW to be used for data fetching
     """
 
+site_address =
+  System.get_env("SITE_ADDRESS") ||
+    raise """
+    environment variable SITE_ADDRESS is missing.
+    This is the address of the AeCanary host to be used where this should be
+    shown to the user for example in links in emails
+    """
+
 config :ae_canary, AeCanary.Repo,
   # ssl: true,
   url: database_url,
@@ -93,7 +101,8 @@ config :ae_canary, AeCanary.Accounts.Guardian,
   secret_key: guardian_secret_key
 
 config :ae_canary,
-  mdw_url: mdw_url
+  mdw_url: mdw_url,
+  site_adress: site_address
 
 config :ae_canary, AeCanary.Mailer,
   adapter: Bamboo.MailgunAdapter,

--- a/config/test.exs
+++ b/config/test.exs
@@ -23,5 +23,7 @@ config :ae_canary, AeCanary.Mdw.Cache.Service,
 
 config :ae_canary, AeCanary.Mailer, adapter: Bamboo.TestAdapter
 
+config :ae_canary, site_address: "test.host"
+
 # Print only warnings and errors during test
 config :logger, level: :warn

--- a/lib/ae_canary/mailer/email.ex
+++ b/lib/ae_canary/mailer/email.ex
@@ -19,6 +19,7 @@ defmodule AeCanary.Email do
     |> assign(:tx, tx)
     |> assign(:exchange, exchange_name)
     |> assign(:addr, addr)
+    |> assign(:site_address, Application.fetch_env!(:ae_canary, :site_address))
     |> render(:big_deposit)
   end
 
@@ -38,6 +39,7 @@ defmodule AeCanary.Email do
     |> assign(:tx, tx)
     |> assign(:exchange, exchange_name)
     |> assign(:addr, addr)
+    |> assign(:site_address, Application.fetch_env!(:ae_canary, :site_address))
     |> render(:boundary)
   end
 end

--- a/lib/ae_canary/mailer/templates/big_deposit.html.eex
+++ b/lib/ae_canary/mailer/templates/big_deposit.html.eex
@@ -1,14 +1,14 @@
 <table role="presentation" style="width:94%;max-width:600px;border:none;border-spacing:0;text-align:left;font-family:Arial,sans-serif;font-size:16px;line-height:22px;color:#363636;">
     <tr>
     <td style="padding:40px 30px 30px 30px;text-align:center;font-size:24px;font-weight:bold;">
-        <a href="https://canary.aepps.com" style="text-decoration:none;">AE Canary</a>
+        <a href="https://<%= @site_address %>" style="text-decoration:none;">AE Canary</a>
     </td>
 </tr>
 <tr>
     <td style="padding:30px;background-color:#f8d7da;color:#842029;border:1px solid transparent;border-radius:5px;border-color:#dc3545">
         <h1 style="margin-top:0;margin-bottom:16px;font-size:20px;line-height:32px;font-weight:bold;letter-spacing:-0.02em;">Notification for exchange <%= @exchange %></h1>
         <ul>
-        <li style="margin:0;"><%= @addr %> has received a deposit of <%= @tx.tx.amount |> round() %> AE. (<a href="https://canary.aepps.com/exchanges/dashboard#<%= @addr %>">link</a>)</li>
+        <li style="margin:0;"><%= @addr %> has received a deposit of <%= @tx.tx.amount |> round() %> AE. (<a href="https://<%= @site_address %>/exchanges/dashboard#<%= @addr %>">link</a>)</li>
         </ul>
     </td>
 </tr>

--- a/lib/ae_canary/mailer/templates/boundary.html.eex
+++ b/lib/ae_canary/mailer/templates/boundary.html.eex
@@ -1,14 +1,14 @@
 <table role="presentation" style="width:94%;max-width:600px;border:none;border-spacing:0;text-align:left;font-family:Arial,sans-serif;font-size:16px;line-height:22px;color:#363636;">
     <tr>
     <td style="padding:40px 30px 30px 30px;text-align:center;font-size:24px;font-weight:bold;">
-        <a href="https://canary.aepps.com" style="text-decoration:none;">AE Canary</a>
+        <a href="https://<%= @site_address %>" style="text-decoration:none;">AE Canary</a>
     </td>
 </tr>
 <tr>
     <td style="padding:30px;background-color:#f8d7da;color:#842029;border:1px solid transparent;border-radius:5px;border-color:#dc3545">
         <h1 style="margin-top:0;margin-bottom:16px;font-size:20px;line-height:32px;font-weight:bold;letter-spacing:-0.02em;">Notification for exchange <%= @exchange %></h1>
         <ul>
-            <li style="margin:0;"><%= @addr %> (<a href="https://canary.aepps.com/exchanges/dashboard#<%= @addr %>">link</a>) exposure crossed a boundary</li>
+            <li style="margin:0;"><%= @addr %> (<a href="https://<%= @site_address %>/exchanges/dashboard#<%= @addr %>">link</a>) exposure crossed a boundary</li>
             <li style="margin:0;">On <%= Timex.format!(@tx.date, "%d %b", :strftime)  %> the exposure <%= round(@tx.message.exposure) %> went over the <strong><%= @tx.message.boundary %></strong> boundary of <%= round(@tx.message.limit) %>.</li>
         </ul>
     </td>

--- a/lib/ae_canary/mailer/templates/boundary.text.eex
+++ b/lib/ae_canary/mailer/templates/boundary.text.eex
@@ -1,5 +1,5 @@
 AE Canary
 
-<%= @addr %> (https://canary.aepps.com/exchanges/dashboard#<%= @addr %>) exposure crossed a boundary.
+<%= @addr %> (https://<%= @site_address %>/exchanges/dashboard#<%= @addr %>) exposure crossed a boundary.
 
 On <%= Timex.format!(@tx.date, "%d %b", :strftime)  %> the exposure <%= round(@tx.message.exposure) %> went over the <strong><%= @tx.message.boundary %></strong> boundary of <%= round(@tx.message.limit) %>.

--- a/lib/ae_canary/mailer/templates/layout.html.eex
+++ b/lib/ae_canary/mailer/templates/layout.html.eex
@@ -39,7 +39,7 @@
     <table role="presentation" style="width:94%;max-width:600px;margin-top:20px;border-radius:5px;border:none;border-spacing:0;text-align:left;font-family:Arial,sans-serif;font-size:16px;line-height:22px;color:#363636;">
         <tr>
             <td style="padding:30px;text-align:center;font-size:12px;background-color:#404040;color:#cccccc;">
-                <p style="margin:0;font-size:14px;line-height:20px;">You are receiving this email because your AeCanary account is configured to receive notifications. Change your preferences at <a href="https://canary.aepps.com/account">account prefs</a></p>
+                <p style="margin:0;font-size:14px;line-height:20px;">You are receiving this email because your AeCanary account is configured to receive notifications. Change your preferences at <a href="https://<%= @site_address %>/account">account prefs</a></p>
             </td>
         </tr>
     </table>

--- a/test/ae_canary/email_sending_test.exs
+++ b/test/ae_canary/email_sending_test.exs
@@ -128,12 +128,12 @@ defmodule AeCanary.EmailDeliveryTest do
   test "Notifications sent only once" do
       users = users_fixture()
       AeCanary.Mdw.Notifier.send_notifications(@alerts_for_last_days, users)
-      assert_email_delivered_with(subject: "[AeCanary] Large deposit notification", to: [{"Test user all", "test1@domain"}])
-      assert_email_delivered_with(subject: "[AeCanary] Large deposit notification", to: [{"Test user only deposits", "test2@domain"}])
-      assert_email_delivered_with(subject: "[AeCanary] Boundary crossed notification", to: [{"Test user all", "test1@domain"}])
-      assert_email_delivered_with(subject: "[AeCanary] Boundary crossed notification", to: [{"Test user only boundaries", "test3@domain"}])
-      assert_email_delivered_with(subject: "[AeCanary] Boundary crossed notification", to: [{"Test user all", "test1@domain"}])
-      assert_email_delivered_with(subject: "[AeCanary] Boundary crossed notification", to: [{"Test user only boundaries", "test3@domain"}])
+      assert_email_delivered_with(subject: "[AeCanary] Large deposit notification", to: [{"Test user all", "test1@domain"}], html_body: ~r/test.host/)
+      assert_email_delivered_with(subject: "[AeCanary] Large deposit notification", to: [{"Test user only deposits", "test2@domain"}], html_body: ~r/test.host/)
+      assert_email_delivered_with(subject: "[AeCanary] Boundary crossed notification", to: [{"Test user all", "test1@domain"}], html_body: ~r/test.host/)
+      assert_email_delivered_with(subject: "[AeCanary] Boundary crossed notification", to: [{"Test user only boundaries", "test3@domain"}], html_body: ~r/test.host/)
+      assert_email_delivered_with(subject: "[AeCanary] Boundary crossed notification", to: [{"Test user all", "test1@domain"}], html_body: ~r/test.host/)
+      assert_email_delivered_with(subject: "[AeCanary] Boundary crossed notification", to: [{"Test user only boundaries", "test3@domain"}], html_body: ~r/test.host/)
 
       assert 6 = length(AeCanary.Notifications.list_notifications())
 


### PR DESCRIPTION
This is already needed for the uat system, but in any case should not be hard coded

This PR is sponsored by the ACF