### PR TITLE
Add user email unique constraint

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -53,7 +53,7 @@ defmodule AeCanary.MixProject do
       {:poison, "~> 3.1"},
       {:timex, "~> 3.7"},
       {:uuid, "~> 1.1"},
-      { :statistics, "~> 0.6.2"},
+      {:statistics, "~> 0.6.2"},
       {:bamboo, "~> 2.2.0"}
     ]
   end
@@ -67,7 +67,8 @@ defmodule AeCanary.MixProject do
   defp aliases do
     [
       setup: ["deps.get", "ecto.setup", "cmd npm install --prefix assets"],
-      "ecto.setup": ["ecto.create", "ecto.migrate", "run priv/repo/seeds.exs"],
+      "ecto.setup": ["ecto.create", "ecto.migrate", "ecto.seeds"],
+      "ecto.seeds": "run priv/repo/seeds.exs",
       "ecto.reset": ["ecto.drop", "ecto.setup"],
       test: ["ecto.create --quiet", "ecto.migrate --quiet", "test"]
     ]

--- a/priv/repo/migrations/20211110135534_add_user_email_unique_constraint.exs
+++ b/priv/repo/migrations/20211110135534_add_user_email_unique_constraint.exs
@@ -1,0 +1,11 @@
+defmodule AeCanary.Repo.Migrations.AddUserEmailUniqueConstraint do
+  use Ecto.Migration
+
+  def up do
+    create unique_index(:users, [:email])
+  end
+
+  def down do
+    drop unique_index(:users, [:email])
+  end
+end

--- a/test/ae_canary/accounts_test.exs
+++ b/test/ae_canary/accounts_test.exs
@@ -45,9 +45,15 @@ defmodule AeCanary.AccountsTest do
 
     test "create_user/1 with valid data creates a user" do
       test_role = fn role ->
-        assert {:ok, %User{} = user} = Accounts.create_user(%{@valid_attrs | role: role})
+        assert {:ok, %User{} = user} =
+                 Accounts.create_user(%{
+                   @valid_attrs
+                   | email: @valid_attrs.email <> " #{role}",
+                     role: role
+                 })
+
         assert user.comment == "some comment"
-        assert user.email == "some email"
+        assert user.email == "some email #{role}"
         assert user.name == "some name"
         assert {:ok, user} == Argon2.check_pass(user, "some password", hash_key: :pass_hash)
         assert user.role == role

--- a/test/ae_canary/accounts_test.exs
+++ b/test/ae_canary/accounts_test.exs
@@ -56,6 +56,11 @@ defmodule AeCanary.AccountsTest do
       Enum.each(@valid_user_roles, test_role)
     end
 
+    test "create_user/1 with duplicated email return error changeset" do
+      assert {:ok, %User{}} = Accounts.create_user(@valid_attrs)
+      assert {:error, %Ecto.Changeset{}} = Accounts.create_user(@valid_attrs)
+    end
+
     test "create_user/1 with invalid data returns error changeset" do
       assert {:error, %Ecto.Changeset{}} = Accounts.create_user(@invalid_attrs)
 


### PR DESCRIPTION
Add missing unique constraint for users email 

```
ae_canary ✗ psql ae_canary_dev -c "select count(*) from users"
 count
-------
     3
(1 row)

 ae_canary ✗ mix ecto.seeds
 ae_canary ✗ psql ae_canary_dev -c "select count(*) from users"
 count
-------
     3
(1 row)

ae_canary ✗ mix ecto.rollback -n 1
16:10:28.556 [info]  == Running 20211110135534 AeCanary.Repo.Migrations.AddUserEmailUniqueConstraint.down/0 forward
16:10:28.559 [info]  drop index users_email_index
16:10:28.562 [info]  == Migrated 20211110135534 in 0.0s

 ae_canary ✗ psql ae_canary_dev -c "select count(*) from users"
 count
-------
     3
(1 row)

 ae_canary ✗ mix ecto.seeds
 ae_canary ✗ psql ae_canary_dev -c "select count(*) from users"
 count
-------
     6
(1 row)

```